### PR TITLE
Unpinned pyside6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-  'PySide6>=6.8,<6.9' # Issue with TableView formatting in 6.9
+  'PySide6'
 ]
 
 [project.urls]

--- a/src/EasyApp/Gui/Components/TableView.qml
+++ b/src/EasyApp/Gui/Components/TableView.qml
@@ -127,11 +127,17 @@ ListView {
 
     function setAllColumnsWidthAndAlignment() {
         for (let item of contentItem.children) {
-            if (item instanceof TableViewDelegate) {
-                for (let columnIndex in item.children[0].children) {
-                    item.children[0].children[columnIndex].width = headerLabelItems[columnIndex].width
-                    if (typeof item.children[0].children[columnIndex].horizontalAlignment !== 'undefined') {
-                        item.children[0].children[columnIndex].horizontalAlignment = headerLabelItems[columnIndex].horizontalAlignment
+            // Check for TableViewDelegate using explicit property
+            if (item.isTableViewDelegate === true) {
+                const rowElement = item.children[0]
+                if (rowElement && rowElement.children) {
+                    for (let columnIndex in rowElement.children) {
+                        if (columnIndex < headerLabelItems.length) {
+                            rowElement.children[columnIndex].width = headerLabelItems[columnIndex].width
+                            if (typeof rowElement.children[columnIndex].horizontalAlignment !== 'undefined') {
+                                rowElement.children[columnIndex].horizontalAlignment = headerLabelItems[columnIndex].horizontalAlignment
+                            }
+                        }
                     }
                 }
             }

--- a/src/EasyApp/Gui/Components/TableView.qml
+++ b/src/EasyApp/Gui/Components/TableView.qml
@@ -128,7 +128,7 @@ ListView {
     function setAllColumnsWidthAndAlignment() {
         for (let item of contentItem.children) {
             // Check for TableViewDelegate using explicit property
-            if (item.isTableViewDelegate === true) {
+            if (item.toString().startsWith('TableViewDelegate_QMLTYPE')) {
                 const rowElement = item.children[0]
                 if (rowElement && rowElement.children) {
                     for (let columnIndex in rowElement.children) {

--- a/src/EasyApp/Gui/Components/TableViewDelegate.qml
+++ b/src/EasyApp/Gui/Components/TableViewDelegate.qml
@@ -9,7 +9,6 @@ Rectangle {
     default property alias contentRowData: contentRow.data
     property alias mouseArea: mouseArea
     property Item tableView: parent === null ? null : parent.parent
-    readonly property bool isTableViewDelegate: true
 
     implicitWidth: parent == null ? 0 : parent.width
     implicitHeight: tableView === null ? EaStyle.Sizes.tableRowHeight : tableView.tableRowHeight

--- a/src/EasyApp/Gui/Components/TableViewDelegate.qml
+++ b/src/EasyApp/Gui/Components/TableViewDelegate.qml
@@ -9,6 +9,7 @@ Rectangle {
     default property alias contentRowData: contentRow.data
     property alias mouseArea: mouseArea
     property Item tableView: parent === null ? null : parent.parent
+    readonly property bool isTableViewDelegate: true
 
     implicitWidth: parent == null ? 0 : parent.width
     implicitHeight: tableView === null ? EaStyle.Sizes.tableRowHeight : tableView.tableRowHeight


### PR DESCRIPTION
Unpinned PySide6 dependencies.

Also, fixed the TableViewDelegate alignment issue that occurred after upgrading to PySide6 > 6.8. The problem was in the `TableView.qml` component, where the 
```
instanceof TableViewDelegate
```
 check was failing to properly identify table delegate instances, causing the width and alignment logic to not be applied.