### PR TITLE
Added a minor theme accent for selections

### DIFF
--- a/src/EasyApp/Gui/Style/Colors.qml
+++ b/src/EasyApp/Gui/Style/Colors.qml
@@ -40,6 +40,7 @@ QtObject {
     onIsDarkPaletteChanged: console.debug(`Is dark palette: ${isDarkPalette}`)
 
     property color themeAccent: isDarkPalette ? "#4ec1ef": "#00a3e3"
+    property color themeAccentMinor: isDarkPalette ? "#4d9dbd" : "#8ad6ed"
     property color themePrimary: isDarkPalette ? "#111" : "#bbb"
 
     property color themeBackground: isDarkPalette ? "#303030" : "#e9e9e9"


### PR DESCRIPTION
In order to use selectModels with TableViews there is a need form appropriate selection colors. 
Current Theme Accent colors are too saturated to be used as selection (IMO), so I introduce a Minor Theme Accent to use instead.

Examples of selection and a hover in light and dark themed tableview are attached. Note that active selection is on the second row and hover is on the fourth row.
![light-theme-selection](https://github.com/user-attachments/assets/765b6d34-a5c6-40fd-8d00-4f10c67b7c3a)
![dark-theme-selection](https://github.com/user-attachments/assets/656b3445-7899-4060-9272-9cfb3b899d95)
