### PR TITLE
Added a content width fix for DialogButtonBox

### DIFF
--- a/src/EasyApp/Gui/Elements/DialogButtonBox.qml
+++ b/src/EasyApp/Gui/Elements/DialogButtonBox.qml
@@ -29,6 +29,7 @@ T.DialogButtonBox {
     delegate: EaElements.Button { highlighted: true }
 
     contentItem: ListView {
+        implicitWidth: contentWidth
         model: control.contentModel
         spacing: control.spacing
         orientation: ListView.Horizontal


### PR DESCRIPTION
 in order to show all 'standardButton's listed in Dialogs instead of just one, templates needed to be fixed.

Now, using
```
EaElements.Dialog{
    standardButtons: Dialog.Ok | Dialog.Cancel
}
```
correctly displays both buttons.