### PR TITLE
Changed the behaviour of TableViewTextInput to indicate enter/return

### DIFF
--- a/src/EasyApp/Gui/Components/TableViewTextInput.qml
+++ b/src/EasyApp/Gui/Components/TableViewTextInput.qml
@@ -8,4 +8,13 @@ EaElements.TextInput {
     height: parent.height
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter
+
+    Keys.onReturnPressed: {
+        accepted()
+        focus = false
+    }
+    Keys.onEnterPressed: {
+        accepted()
+        focus = false
+    }
 }

--- a/src/EasyApp/Gui/Components/TableViewTextInput.qml
+++ b/src/EasyApp/Gui/Components/TableViewTextInput.qml
@@ -8,13 +8,4 @@ EaElements.TextInput {
     height: parent.height
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter
-
-    Keys.onReturnPressed: {
-        accepted()
-        focus = false
-    }
-    Keys.onEnterPressed: {
-        accepted()
-        focus = false
-    }
 }

--- a/src/EasyApp/Gui/Elements/TextField.qml
+++ b/src/EasyApp/Gui/Elements/TextField.qml
@@ -11,6 +11,7 @@ T.TextField {
     id: control
 
     property bool warned: false
+    property bool enterFlash: false
 
     implicitWidth: implicitBackgroundWidth + leftInset + rightInset
                    || Math.max(contentWidth, placeholder.implicitWidth) + leftPadding + rightPadding
@@ -31,7 +32,9 @@ T.TextField {
     font.pixelSize: EaStyle.Sizes.fontPixelSize
     //font.bold: control.activeFocus ? true : false
 
-    color: warned ?
+    color: enterFlash ?
+               EaStyle.Colors.themeForeground :
+               warned ?
                EaStyle.Colors.red :
                !enabled ?
                    EaStyle.Colors.themeForegroundDisabled :
@@ -80,21 +83,17 @@ T.TextField {
         Behavior on border.color { EaAnimations.ThemeChange {} }
     }
 
-    // Visual feedback for the user that editing finish was accepted
-    function _commit(event) {
-        if (!acceptableInput) {
-            warned = true
-            event.accepted = true
-            return
-        }
-        warned = false
-        accepted()
-        focus = false
-        event.accepted = true
+    onAccepted: {
+        control.enterFlash = true
+        enterFlashTimer.start()
     }
 
-    Keys.onReturnPressed: (event) => _commit(event)
-    Keys.onEnterPressed:  (event) => _commit(event)
+    // Visual feedback for the user that editing finish was accepted
+    Timer {
+        id: enterFlashTimer
+        interval: 180
+        onTriggered: control.enterFlash = false
+    }
 
     //Mouse area to react on click events
     MouseArea {

--- a/src/EasyApp/Gui/Elements/TextField.qml
+++ b/src/EasyApp/Gui/Elements/TextField.qml
@@ -81,14 +81,20 @@ T.TextField {
     }
 
     // Visual feedback for the user that editing finish was accepted
-    Keys.onReturnPressed: {
+    function _commit(event) {
+        if (!acceptableInput) {
+            warned = true
+            event.accepted = true
+            return
+        }
+        warned = false
         accepted()
         focus = false
+        event.accepted = true
     }
-    Keys.onEnterPressed: {
-        accepted()
-        focus = false
-    }
+
+    Keys.onReturnPressed: (event) => _commit(event)
+    Keys.onEnterPressed:  (event) => _commit(event)
 
     //Mouse area to react on click events
     MouseArea {

--- a/src/EasyApp/Gui/Elements/TextField.qml
+++ b/src/EasyApp/Gui/Elements/TextField.qml
@@ -80,6 +80,16 @@ T.TextField {
         Behavior on border.color { EaAnimations.ThemeChange {} }
     }
 
+    // Visual feedback for the user that editing finish was accepted
+    Keys.onReturnPressed: {
+        accepted()
+        focus = false
+    }
+    Keys.onEnterPressed: {
+        accepted()
+        focus = false
+    }
+
     //Mouse area to react on click events
     MouseArea {
         id: mouseArea

--- a/src/EasyApp/Gui/Elements/TextInput.qml
+++ b/src/EasyApp/Gui/Elements/TextInput.qml
@@ -14,6 +14,7 @@ T.TextField {
     property bool warned: false
     property bool selected: false
     property bool minored: false
+    property bool enterFlash: false
 
     implicitWidth: implicitBackgroundWidth + leftInset + rightInset ||
                    Math.max(contentWidth, placeholder.implicitWidth) + leftPadding + rightPadding
@@ -27,7 +28,9 @@ T.TextField {
     font.pixelSize: EaStyle.Sizes.fontPixelSize
     font.bold: control.activeFocus ? true : false
 
-    color: warned ?
+    color: enterFlash ?
+               EaStyle.Colors.themeForeground :
+               warned ?
                EaStyle.Colors.red :
                !enabled || readOnly || minored ?
                    EaStyle.Colors.themeForegroundMinor :
@@ -66,21 +69,17 @@ T.TextField {
         color: 'transparent'
     }
 
-    // Visual feedback for the user that editing finish was accepted
-    function _commit(event) {
-        if (!acceptableInput) {
-            warned = true
-            event.accepted = true
-            return
-        }
-        warned = false
-        accepted()
-        focus = false
-        event.accepted = true
+    onAccepted: {
+        control.enterFlash = true
+        enterFlashTimer.start()
     }
 
-    Keys.onReturnPressed: (event) => _commit(event)
-    Keys.onEnterPressed:  (event) => _commit(event)
+    // Visual feedback for the user that editing finish was accepted
+    Timer {
+        id: enterFlashTimer
+        interval: 180
+        onTriggered: control.enterFlash = false
+    }
 
     //Mouse area to react on click events
     MouseArea {

--- a/src/EasyApp/Gui/Elements/TextInput.qml
+++ b/src/EasyApp/Gui/Elements/TextInput.qml
@@ -67,14 +67,20 @@ T.TextField {
     }
 
     // Visual feedback for the user that editing finish was accepted
-    Keys.onReturnPressed: {
+    function _commit(event) {
+        if (!acceptableInput) {
+            warned = true
+            event.accepted = true
+            return
+        }
+        warned = false
         accepted()
         focus = false
+        event.accepted = true
     }
-    Keys.onEnterPressed: {
-        accepted()
-        focus = false
-    }
+
+    Keys.onReturnPressed: (event) => _commit(event)
+    Keys.onEnterPressed:  (event) => _commit(event)
 
     //Mouse area to react on click events
     MouseArea {

--- a/src/EasyApp/Gui/Elements/TextInput.qml
+++ b/src/EasyApp/Gui/Elements/TextInput.qml
@@ -66,6 +66,16 @@ T.TextField {
         color: 'transparent'
     }
 
+    // Visual feedback for the user that editing finish was accepted
+    Keys.onReturnPressed: {
+        accepted()
+        focus = false
+    }
+    Keys.onEnterPressed: {
+        accepted()
+        focus = false
+    }
+
     //Mouse area to react on click events
     MouseArea {
         id: mouseArea


### PR DESCRIPTION
Right now any TableViewTextInput (and TextInput/TextField in general) based elements rely on Accepted and EditingFinished signals to tie in backend logic. The issue with such an approach is that pressing enter fires both signals, while the focus remains in the element providing no visual feedback to the user that the input was accepted. Moreover, adding 'focus = true' in code might accidentally fire secondary EditingFinished signal. 

This PR introduces a way to provide visual feedback to the user on enter/return pressed.
Behaviour of Accepted/EditingFinished is not changed: Accepted is fired on enter/return, EditingFinished is fired on enter/return or focus loss.