### PR TITLE
Fixed reference error in slider tooltip

### DIFF
--- a/src/EasyApp/Gui/Elements/Slider.qml
+++ b/src/EasyApp/Gui/Elements/Slider.qml
@@ -31,7 +31,7 @@ T.Slider {
         EaElements.ToolTip {
             id: toolTip
 
-            visible: slider.pressed || slider.hovered
+            visible: control.pressed || control.hovered
             //text: EaLogic.Utils.toDefaultPrecision(control.value)
         }
     }


### PR DESCRIPTION
EasyApp slider element is used by default in templated EasyScience-based app, which makes it throw a reference error on every launch. This is a quick fix for the reference error. 
Doesn't really affect much except a botched tooltip on slider.