### PR TITLE
scrollbar and scrollindicator size and color updates

### DIFF
--- a/src/EasyApp/Gui/Elements/ScrollBar.qml
+++ b/src/EasyApp/Gui/Elements/ScrollBar.qml
@@ -12,17 +12,18 @@ T.ScrollBar {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              implicitContentHeight + topPadding + bottomPadding)
 
-
+    property bool snapToHeader: false
     property int _padding: control.interactive ? 1 : 2
     padding: _padding
-    topInset: parent.showHeader ? parent.tableRowHeight : 0
-    topPadding: parent.showHeader ? parent.tableRowHeight + _padding : 0
+    topInset: snapToHeader && parent.showHeader ? parent.tableRowHeight : 0
+    topPadding: snapToHeader && parent.showHeader ? parent.tableRowHeight + _padding : 0
     visible: control.policy !== T.ScrollBar.AlwaysOff
     minimumSize: orientation === Qt.Horizontal ? height / width : width / height
 
     contentItem: Rectangle {
-        implicitWidth: control.interactive ? 6 : 4
-        implicitHeight: control.interactive ? 6 : 4
+        implicitWidth: 4
+        implicitHeight: 4
+        radius: width / 4
 
         color: control.pressed ?
                    EaStyle.Colors.themeAccent :
@@ -33,8 +34,8 @@ T.ScrollBar {
     }
 
     background: Rectangle {
-        implicitWidth: control.interactive ? 8 : 4
-        implicitHeight: control.interactive ? 8 : 4
+        implicitWidth: control.interactive ? 7 : 4
+        implicitHeight: control.interactive ? 7 : 4
         color: "#0e000000"
         opacity: 0.0
         visible: control.interactive

--- a/src/EasyApp/Gui/Elements/ScrollBar.qml
+++ b/src/EasyApp/Gui/Elements/ScrollBar.qml
@@ -21,8 +21,8 @@ T.ScrollBar {
     minimumSize: orientation === Qt.Horizontal ? height / width : width / height
 
     contentItem: Rectangle {
-        implicitWidth: 4
-        implicitHeight: 4
+        implicitWidth: control.hovered ? 8 : 4
+        implicitHeight: control.hovered ? 8 : 4
         radius: width / 4
 
         color: control.pressed ?
@@ -31,14 +31,28 @@ T.ScrollBar {
                        EaStyle.Colors.themeForegroundMinor :
                        EaStyle.Colors.themeForegroundDisabled
         opacity: 0.0
+
+        Behavior on implicitWidth {
+            NumberAnimation { duration: 150; easing.type: Easing.InOutQuad }
+        }
+        Behavior on implicitHeight {
+            NumberAnimation { duration: 150; easing.type: Easing.InOutQuad }
+        }
     }
 
     background: Rectangle {
-        implicitWidth: control.interactive ? 7 : 4
-        implicitHeight: control.interactive ? 7 : 4
+        implicitWidth: control.hovered ? 14 : (control.interactive ? 7 : 4)
+        implicitHeight: control.hovered ? 14 : (control.interactive ? 7 : 4)
         color: "#0e000000"
         opacity: 0.0
         visible: control.interactive
+
+        Behavior on implicitWidth {
+            NumberAnimation { duration: 150; easing.type: Easing.InOutQuad }
+        }
+        Behavior on implicitHeight {
+            NumberAnimation { duration: 150; easing.type: Easing.InOutQuad }
+        }
     }
 
     states: State {

--- a/src/EasyApp/Gui/Elements/ScrollBar.qml
+++ b/src/EasyApp/Gui/Elements/ScrollBar.qml
@@ -21,8 +21,6 @@ T.ScrollBar {
     minimumSize: orientation === Qt.Horizontal ? height / width : width / height
 
     contentItem: Rectangle {
-        implicitWidth: control.hovered ? 8 : 4
-        implicitHeight: control.hovered ? 8 : 4
         radius: width / 4
 
         color: control.pressed ?
@@ -31,18 +29,11 @@ T.ScrollBar {
                        EaStyle.Colors.themeForegroundMinor :
                        EaStyle.Colors.themeForegroundDisabled
         opacity: 0.0
-
-        Behavior on implicitWidth {
-            NumberAnimation { duration: 150; easing.type: Easing.InOutQuad }
-        }
-        Behavior on implicitHeight {
-            NumberAnimation { duration: 150; easing.type: Easing.InOutQuad }
-        }
     }
 
     background: Rectangle {
-        implicitWidth: control.hovered ? 14 : (control.interactive ? 7 : 4)
-        implicitHeight: control.hovered ? 14 : (control.interactive ? 7 : 4)
+        implicitWidth: (control.hovered || control.pressed) ? 12 : (control.interactive ? 7 : 4)
+        implicitHeight: (control.hovered || control.pressed) ? 12 : (control.interactive ? 7 : 4)
         color: "#0e000000"
         opacity: 0.0
         visible: control.interactive

--- a/src/EasyApp/Gui/Elements/ScrollBar.qml
+++ b/src/EasyApp/Gui/Elements/ScrollBar.qml
@@ -12,16 +12,11 @@ T.ScrollBar {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              implicitContentHeight + topPadding + bottomPadding)
 
-    property bool snapToHeader: false
-    property int _padding: control.interactive ? 1 : 2
-    padding: _padding
-    topInset: snapToHeader && parent.showHeader ? parent.tableRowHeight : 0
-    topPadding: snapToHeader && parent.showHeader ? parent.tableRowHeight + _padding : 0
+    padding: control.interactive ? 1 : 2
     visible: control.policy !== T.ScrollBar.AlwaysOff
     minimumSize: orientation === Qt.Horizontal ? height / width : width / height
 
     contentItem: Rectangle {
-        radius: width / 4
 
         color: control.pressed ?
                    EaStyle.Colors.themeAccent :

--- a/src/EasyApp/Gui/Elements/ScrollBar.qml
+++ b/src/EasyApp/Gui/Elements/ScrollBar.qml
@@ -2,6 +2,8 @@ import QtQuick
 import QtQuick.Templates as T
 import QtQuick.Controls.Material
 
+import EasyApp.Gui.Style as EaStyle
+
 T.ScrollBar {
     id: control
 
@@ -10,25 +12,29 @@ T.ScrollBar {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              implicitContentHeight + topPadding + bottomPadding)
 
-    padding: control.interactive ? 1 : 2
+
+    property int _padding: control.interactive ? 1 : 2
+    padding: _padding
+    topInset: parent.showHeader ? parent.tableRowHeight : 0
+    topPadding: parent.showHeader ? parent.tableRowHeight + _padding : 0
     visible: control.policy !== T.ScrollBar.AlwaysOff
     minimumSize: orientation === Qt.Horizontal ? height / width : width / height
 
     contentItem: Rectangle {
-        implicitWidth: control.interactive ? 13 : 4
-        implicitHeight: control.interactive ? 13 : 4
+        implicitWidth: control.interactive ? 6 : 4
+        implicitHeight: control.interactive ? 6 : 4
 
         color: control.pressed ?
-                   control.Material.scrollBarPressedColor :
+                   EaStyle.Colors.themeAccent :
                    control.interactive && control.hovered ?
-                       control.Material.scrollBarHoveredColor :
-                       control.Material.scrollBarColor
+                       EaStyle.Colors.themeForegroundMinor :
+                       EaStyle.Colors.themeForegroundDisabled
         opacity: 0.0
     }
 
     background: Rectangle {
-        implicitWidth: control.interactive ? 16 : 4
-        implicitHeight: control.interactive ? 16 : 4
+        implicitWidth: control.interactive ? 8 : 4
+        implicitHeight: control.interactive ? 8 : 4
         color: "#0e000000"
         opacity: 0.0
         visible: control.interactive

--- a/src/EasyApp/Gui/Elements/ScrollIndicator.qml
+++ b/src/EasyApp/Gui/Elements/ScrollIndicator.qml
@@ -19,6 +19,7 @@ T.ScrollIndicator {
     contentItem: Rectangle {
         implicitWidth: 4
         implicitHeight: 4
+        radius: width / 4
 
         color: EaStyle.Colors.themeForegroundDisabled
         visible: control.size < 1.0

--- a/src/EasyApp/Gui/Elements/ScrollIndicator.qml
+++ b/src/EasyApp/Gui/Elements/ScrollIndicator.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import QtQuick.Templates as T
 
+import EasyApp.Gui.Style as EaStyle
+
 T.ScrollIndicator {
     id: control
 
@@ -9,13 +11,16 @@ T.ScrollIndicator {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              implicitContentHeight + topPadding + bottomPadding)
 
-    padding: 2
+    property int _padding: 2
+    padding: _padding
+    topInset: parent.showHeader ? parent.tableRowHeight : 0
+    topPadding: parent.showHeader ? parent.tableRowHeight + _padding : 0
 
     contentItem: Rectangle {
         implicitWidth: 4
         implicitHeight: 4
 
-        ///color: control.Material.scrollBarColor
+        color: EaStyle.Colors.themeForegroundDisabled
         visible: control.size < 1.0
         opacity: 0.0
 

--- a/src/EasyApp/Gui/Elements/ScrollIndicator.qml
+++ b/src/EasyApp/Gui/Elements/ScrollIndicator.qml
@@ -11,7 +11,7 @@ T.ScrollIndicator {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              implicitContentHeight + topPadding + bottomPadding)
 
-    padding: control.interactive ? 1 : 2
+    padding: 2
 
     contentItem: Rectangle {
         implicitWidth: 4

--- a/src/EasyApp/Gui/Elements/ScrollIndicator.qml
+++ b/src/EasyApp/Gui/Elements/ScrollIndicator.qml
@@ -11,15 +11,11 @@ T.ScrollIndicator {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              implicitContentHeight + topPadding + bottomPadding)
 
-    property int _padding: 2
-    padding: _padding
-    topInset: parent.showHeader ? parent.tableRowHeight : 0
-    topPadding: parent.showHeader ? parent.tableRowHeight + _padding : 0
+    padding: control.interactive ? 1 : 2
 
     contentItem: Rectangle {
         implicitWidth: 4
         implicitHeight: 4
-        radius: width / 4
 
         color: EaStyle.Colors.themeForegroundDisabled
         visible: control.size < 1.0


### PR DESCRIPTION
These PR addresses the EaElements ScrollBar and ScrollIndicator.
They colors were using references to control.Material and I tried updating them to EaStyles colors.

The size of the scrollbar changed to smaller, which fits nicely with other EaStyles.
I also added a slight radius as the buttons seem to have.

Also added TopPadding and TopInset for the ScrollBar and the ScrollIndicator: with our tableviews having `showHeader: true` and `headerPositioning: ListView.OverlayHeader` snapping the scrollbar and scrollindicators top sides to the header just makes sense. But this seems too much tied to current TableView implementation, so I'm not sure.

Free scrollBar: 
<img width="721" height="308" alt="image" src="https://github.com/user-attachments/assets/da0b8dff-3637-455f-8f72-a01759e09f12" />
<img width="268" height="126" alt="image" src="https://github.com/user-attachments/assets/cd263137-d3a7-4951-a5fb-549a73b91a0d" />

Active scrollBar:
<img width="333" height="170" alt="image" src="https://github.com/user-attachments/assets/95e9ddd3-0856-4d54-b61c-3d0815a65753" />
<img width="346" height="137" alt="image" src="https://github.com/user-attachments/assets/6783da28-b4d5-4a17-98f9-5c45f7b84698" />


Hover scrollBar
<img width="253" height="143" alt="image" src="https://github.com/user-attachments/assets/c384009d-f568-4400-8a7b-e9117da59883" />
<img width="358" height="161" alt="image" src="https://github.com/user-attachments/assets/91a0d277-08ec-42a9-9657-9d06a91b57af" />


scrollIndicator
<img width="334" height="201" alt="image" src="https://github.com/user-attachments/assets/a6e83b00-e267-47f8-8500-bc94c4109ffd" />
<img width="412" height="251" alt="image" src="https://github.com/user-attachments/assets/a186c6b6-dca0-4ff3-bc3d-bda3e50729de" />



