### PR TITLE
Scroll bar interactive fix

### DIFF
--- a/src/EasyApp/Gui/Elements/ScrollBar.qml
+++ b/src/EasyApp/Gui/Elements/ScrollBar.qml
@@ -12,7 +12,7 @@ T.ScrollBar {
     implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
                              implicitContentHeight + topPadding + bottomPadding)
 
-    padding: control.interactive ? 1 : 2
+    padding: 1
     visible: control.policy !== T.ScrollBar.AlwaysOff
     minimumSize: orientation === Qt.Horizontal ? height / width : width / height
 
@@ -27,8 +27,8 @@ T.ScrollBar {
     }
 
     background: Rectangle {
-        implicitWidth: (control.hovered || control.pressed) ? 12 : (control.interactive ? 7 : 4)
-        implicitHeight: (control.hovered || control.pressed) ? 12 : (control.interactive ? 7 : 4)
+        implicitWidth: control.interactive && (control.hovered || control.pressed) ? 12 : 6
+        implicitHeight: control.interactive && (control.hovered || control.pressed) ? 12 : 6
         color: "#0e000000"
         opacity: 0.0
         visible: control.interactive


### PR DESCRIPTION
The issue with previous implementation was that with `interactive: false` the background gets the 4px width, and contentItem width is then recalculated to 0 but widening it and making it visible on hover.

The fix makes the scrollBar to behave like scrollIndicator if `interactive: false`

The fix ensures the contentItem is visible when non-interactive and makes the width logic simpler: if the scrollBar is interactive, we have width-changing logic, if not - the width doesn't change on hover. The wider padding for non-interactive item looks worse, as it just creates a 1px detatchment from the border, so I removed that as well. 