### PR TITLE
Lighten the disabled foreground color in the dark theme

### DIFF
--- a/src/EasyApp/Gui/Style/Colors.qml
+++ b/src/EasyApp/Gui/Style/Colors.qml
@@ -50,7 +50,7 @@ QtObject {
 
     property color themeForeground: isDarkPalette ? "#eee" : "#333"
     property color themeForegroundMinor: isDarkPalette ? "#888" : "#aaa"
-    property color themeForegroundDisabled: isDarkPalette ? "#555": "#bbb" // control.Material.hintTextColor
+    property color themeForegroundDisabled: isDarkPalette ? "#666": "#bbb" // control.Material.hintTextColor
     property color themeForegroundHovered: themeAccent
     property color themeForegroundHighlight: isDarkPalette ? '#FFAB91' : '#FF5722'
 


### PR DESCRIPTION
While trying to choose the selection colors for a new ListView, I found it hard to choose the ones that would have enough contrast by themselves but also had contrast with disabled TableViewLabels in the delegate. But this issue existed only for the dark theme.
<img width="710" height="349" alt="1_initial_contrast_dark" src="https://github.com/user-attachments/assets/728b52cb-8d84-4e68-b2d0-a48d0203e4d1" />
<img width="724" height="260" alt="2_initial_contrast_light" src="https://github.com/user-attachments/assets/3fcce46d-1675-4e39-9589-b096fb8a639b" />

So I opened the color wheels for the tableview background colors and disabled color:
<img width="2220" height="895" alt="3_HSB_for_colors" src="https://github.com/user-attachments/assets/956bda0a-99e3-4873-9a9e-fd03eeb8990e" />

The contrast between light-theme disabled and background is ~25, but for dark theme it's just ~10. 
Considering that dark-themed contrast shouldn't be 1to1 match to light-theme, I tried changing the color for the label to bump the contrast up. Here is how it looks with 666 color (17 points difference from the background): the type label has the original disabled color, while atoms column has the new 666 color.
<img width="754" height="246" alt="4_proposed_contrast_dark" src="https://github.com/user-attachments/assets/fb406bd3-69d7-4bde-9528-95bfe8ef6013" />
