### PR TITLE
Fix the reference error in Parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules/
 *.pyproject.user
 *.pyproject.user.*
 CMakeLists.txt.user*
+*settings.ini
 
 # PyCharm
 .idea/

--- a/src/EasyApplication/Gui/Elements/Parameter.qml
+++ b/src/EasyApplication/Gui/Elements/Parameter.qml
@@ -33,6 +33,7 @@ EaElements.TextField {
         anchors.verticalCenter: control.verticalCenter
         leftPadding: EaStyle.Sizes.fontPixelSize * 0.5
         rightPadding: EaStyle.Sizes.fontPixelSize * 0.75
+        topPadding: EaStyle.Sizes.fontPixelSize * 0.25
 
         font: control.font
         color: control.placeholderTextColor

--- a/src/EasyApplication/Gui/Elements/Parameter.qml
+++ b/src/EasyApplication/Gui/Elements/Parameter.qml
@@ -19,7 +19,6 @@ EaElements.TextField {
     topInset: title === '' ? 0 : EaStyle.Sizes.fontPixelSize * 1.5
     topPadding: topInset + padding
 
-    width: parameterFieldWidth()
     placeholderText: ''
 
     EaElements.Label {


### PR DESCRIPTION
Instantiating `EaElements.Parameter` component as is results in a reference error:
`EasyApp/src/EasyApplication/Gui/Elements/Parameter.qml:22:5: ReferenceError: parameterFieldWidth is not defined`

This PR removes `width` definition from `EaElements.Parameter`, which results in a fallback on `TextField`'s `ImplicitWidth`.